### PR TITLE
chore: apply PHPCS in /tests directory, cleanup config file

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,22 +1,13 @@
 <?xml version="1.0"?>
 <ruleset>
-	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki" />
-	<!-- don't need to document typed return values -->
-	<rule ref="MediaWiki.Commenting.FunctionComment.MissingReturn">
-		<severity>0</severity>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturn" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate" />
+		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate" />
 	</rule>
-	<rule ref="MediaWiki.Commenting.FunctionComment.MissingDocumentationPublic">
-		<severity>0</severity>
-	</rule>
-	<!-- don't need to document private members -->
-	<rule ref="MediaWiki.Commenting.FunctionComment.MissingDocumentationPrivate">
-		<severity>0</severity>
-	</rule>
-	<rule ref="MediaWiki.Commenting.PropertyDocumentation.MissingDocumentationPrivate">
-		<severity>0</severity>
-	</rule>
-
-	<rule ref="Squiz.Commenting.FunctionComment.IncorrectTypeHint"/>
+	<rule ref="Squiz.Commenting.FunctionComment.IncorrectTypeHint" />
 	<rule ref="Generic.Files.LineLength">
 		<properties>
 			<!-- inherited line limit from MediaWiki is 100; make it at least 120 -->
@@ -25,8 +16,6 @@
 	</rule>
 
 	<file>.</file>
-	<exclude-pattern>/tests/*</exclude-pattern>
-	<exclude-pattern>.history</exclude-pattern>
 	<arg name="bootstrap" value="./vendor/mediawiki/mediawiki-codesniffer/utils/bootstrap-ci.php" />
 	<arg name="extensions" value="php" />
 	<arg name="encoding" value="UTF-8" />

--- a/tests/DogTest.php
+++ b/tests/DogTest.php
@@ -2,7 +2,6 @@
 
 namespace Neoncitylights\ExampleLibrary\Tests;
 
-use Neoncitylights\ExampleLibrary\IAnimal;
 use Neoncitylights\ExampleLibrary\Dog;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
- fix: remove obsolete .inc file extension
- chore: whitespace formatting in .phpcs.xml
- chore: cleanup .phpcs.xml with nested `<exclude>`