### PR TITLE
ci: simplify main workflow

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,9 +7,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  PHP_LATEST: 8.3
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -41,12 +38,3 @@ jobs:
       run: composer install --prefer-dist --no-progress
     - name: Run test suite
       run: composer test
-
-  ci-success:
-    runs-on: ubuntu-latest
-    name: ci-success
-    needs:
-      - build
-    steps:
-      - name: ✅ CI succeeded
-        run: exit 0


### PR DESCRIPTION
- remove unused environment variable `PHP_LATEST`, originally used as `docs` job which was moved to a separate workflow
- remove `ci_success` job